### PR TITLE
Removed default user and made the setup of the user id and gid explicit.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM bitwalker/alpine-elixir-phoenix:1.10.3
 LABEL maintainer="Chris Garrett (https://github.com/chris-garrett/docker-phoenix-dev)"
-LABEL description="Phoenix 20.07.18 Development Image"
+LABEL description="Phoenix 20.07.19 Development Image"
 
 USER root
 
@@ -10,8 +10,10 @@ RUN set -x \
   && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-v0.6.1.tar.gz \
   && rm dockerize-alpine-linux-amd64-v0.6.1.tar.gz \
   && mix archive.install hex phx_new --force \
-  && adduser -s /bin/bash -D sprout \
-  && chown -R sprout:sprout /opt/app /opt/hex /home/sprout \
+  && deluser default \
+  && addgroup -g 2000 sprout \
+  && adduser -s /bin/bash -H -D -G sprout -u 1001 sprout \
+  && chown -R sprout:sprout /opt/app /opt/hex \
   && rm -rf /var/cache/apk/*
 
 USER sprout

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docker-phoenix-dev
 
-* Phoenix 20.07.18
+* Phoenix 20.07.19
 
 ## Versions
 - Phoenix 1.10.3 - https://phoenixframework.org/
@@ -12,12 +12,12 @@
 ```
 docker run --rm -it \
   -v ${pwd}/src:/opt/app \
-  chrisgarrett/phoenix-dev:20.07.18 
+  chrisgarrett/phoenix-dev:20.07.19 
 ```
 
 Windows cmd
 ```
-docker run --rm -it -v %cd%/src:/opt/app chrisgarrett/phoenix-dev:20.07.18 
+docker run --rm -it -v %cd%/src:/opt/app chrisgarrett/phoenix-dev:20.07.19 
 ```
 
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,7 @@ version: '2.6'
 vars:
   PHOENIX_VERSION: 1.10.3
   DOCKERIZE_VERSION: v0.6.1
-  IMAGE_VERSION: 20.07.18
+  IMAGE_VERSION: 20.07.19
   IMAGE_NAME: chrisgarrett/phoenix-dev
 
 
@@ -63,8 +63,10 @@ tasks:
           && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-{{.DOCKERIZE_VERSION}}.tar.gz \\
           && rm dockerize-alpine-linux-amd64-{{.DOCKERIZE_VERSION}}.tar.gz \\
           && mix archive.install hex phx_new --force \\
-          && adduser -s /bin/bash -D sprout \\
-          && chown -R sprout:sprout /opt/app /opt/hex /home/sprout \\
+          && deluser default \\
+          && addgroup -g 2000 sprout \\
+          && adduser -s /bin/bash -H -D -G sprout -u 1001 sprout \\
+          && chown -R sprout:sprout /opt/app /opt/hex \\
           && rm -rf /var/cache/apk/*
 
         USER sprout


### PR DESCRIPTION
Did this change and updated local environment to have a group with the same name/id and to match the local user id so that live updating can happen without having to be sudo for every save. Probably the better way to go down the road is to make the user a high user id and make a new user on local dev environment with the same userid/groupid but this stop gap will work for now for development.